### PR TITLE
feat: add environment config module

### DIFF
--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -1,0 +1,30 @@
+import 'dotenv/config';
+
+const storagePrefix = 'STORAGE_';
+const storageEntries = Object.entries(process.env).filter(([key]) =>
+  key.startsWith(storagePrefix)
+);
+
+const storage = Object.fromEntries(storageEntries) as Record<string, string | undefined>;
+
+export interface EnvConfig {
+  mongoUri: string | undefined;
+  redisUrl: string | undefined;
+  jwtSecret: string | undefined;
+  emailProvider: string | undefined;
+  storage: Record<string, string | undefined>;
+  baseUrl: string | undefined;
+  tenantDefaultTimezone: string | undefined;
+}
+
+const config: EnvConfig = {
+  mongoUri: process.env.MONGO_URI,
+  redisUrl: process.env.REDIS_URL,
+  jwtSecret: process.env.JWT_SECRET,
+  emailProvider: process.env.EMAIL_PROVIDER,
+  storage,
+  baseUrl: process.env.BASE_URL,
+  tenantDefaultTimezone: process.env.TENANT_DEFAULT_TIMEZONE
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add typed environment configuration for server

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:server`


------
https://chatgpt.com/codex/tasks/task_e_689ee336d6288326855ac61b9b3917da