### PR TITLE
feat: add tenant scoped models

### DIFF
--- a/server/src/models/AuditLog.ts
+++ b/server/src/models/AuditLog.ts
@@ -1,0 +1,15 @@
+import { Schema, model, Types } from 'mongoose';
+
+export interface AuditLog {
+  tenantId: Types.ObjectId;
+  createdAt: Date;
+}
+
+const AuditLogSchema = new Schema<AuditLog>({
+  tenantId: { type: Schema.Types.ObjectId, required: true },
+  createdAt: { type: Date, required: true },
+});
+
+AuditLogSchema.index({ tenantId: 1, createdAt: 1 });
+
+export default model<AuditLog>('AuditLog', AuditLogSchema);

--- a/server/src/models/Council.ts
+++ b/server/src/models/Council.ts
@@ -1,0 +1,15 @@
+import { Schema, model, Types } from 'mongoose';
+
+export interface Council {
+  tenantId: Types.ObjectId;
+  name: string;
+}
+
+const CouncilSchema = new Schema<Council>({
+  tenantId: { type: Schema.Types.ObjectId, required: true },
+  name: { type: String, required: true },
+});
+
+CouncilSchema.index({ tenantId: 1, name: 1 });
+
+export default model<Council>('Council', CouncilSchema);

--- a/server/src/models/Customer.ts
+++ b/server/src/models/Customer.ts
@@ -1,0 +1,15 @@
+import { Schema, model, Types } from 'mongoose';
+
+export interface Customer {
+  tenantId: Types.ObjectId;
+  email: string;
+}
+
+const CustomerSchema = new Schema<Customer>({
+  tenantId: { type: Schema.Types.ObjectId, required: true },
+  email: { type: String, required: true },
+});
+
+CustomerSchema.index({ tenantId: 1, email: 1 });
+
+export default model<Customer>('Customer', CustomerSchema);

--- a/server/src/models/Document.ts
+++ b/server/src/models/Document.ts
@@ -1,0 +1,15 @@
+import { Schema, model, Types } from 'mongoose';
+
+export interface Document {
+  tenantId: Types.ObjectId;
+  title: string;
+}
+
+const DocumentSchema = new Schema<Document>({
+  tenantId: { type: Schema.Types.ObjectId, required: true },
+  title: { type: String, required: true },
+});
+
+DocumentSchema.index({ tenantId: 1, title: 1 });
+
+export default model<Document>('Document', DocumentSchema);

--- a/server/src/models/EmailMsg.ts
+++ b/server/src/models/EmailMsg.ts
@@ -1,0 +1,15 @@
+import { Schema, model, Types } from 'mongoose';
+
+export interface EmailMsg {
+  tenantId: Types.ObjectId;
+  messageId: string;
+}
+
+const EmailMsgSchema = new Schema<EmailMsg>({
+  tenantId: { type: Schema.Types.ObjectId, required: true },
+  messageId: { type: String, required: true },
+});
+
+EmailMsgSchema.index({ tenantId: 1, messageId: 1 });
+
+export default model<EmailMsg>('EmailMsg', EmailMsgSchema);

--- a/server/src/models/Membership.ts
+++ b/server/src/models/Membership.ts
@@ -1,0 +1,15 @@
+import { Schema, model, Types } from 'mongoose';
+
+export interface Membership {
+  tenantId: Types.ObjectId;
+  userId: Types.ObjectId;
+}
+
+const MembershipSchema = new Schema<Membership>({
+  tenantId: { type: Schema.Types.ObjectId, required: true },
+  userId: { type: Schema.Types.ObjectId, required: true },
+});
+
+MembershipSchema.index({ tenantId: 1, userId: 1 });
+
+export default model<Membership>('Membership', MembershipSchema);

--- a/server/src/models/PriceList.ts
+++ b/server/src/models/PriceList.ts
@@ -1,0 +1,15 @@
+import { Schema, model, Types } from 'mongoose';
+
+export interface PriceList {
+  tenantId: Types.ObjectId;
+  name: string;
+}
+
+const PriceListSchema = new Schema<PriceList>({
+  tenantId: { type: Schema.Types.ObjectId, required: true },
+  name: { type: String, required: true },
+});
+
+PriceListSchema.index({ tenantId: 1, name: 1 });
+
+export default model<PriceList>('PriceList', PriceListSchema);

--- a/server/src/models/Project.ts
+++ b/server/src/models/Project.ts
@@ -1,0 +1,15 @@
+import { Schema, model, Types } from 'mongoose';
+
+export interface Project {
+  tenantId: Types.ObjectId;
+  name: string;
+}
+
+const ProjectSchema = new Schema<Project>({
+  tenantId: { type: Schema.Types.ObjectId, required: true },
+  name: { type: String, required: true },
+});
+
+ProjectSchema.index({ tenantId: 1, name: 1 });
+
+export default model<Project>('Project', ProjectSchema);

--- a/server/src/models/Proposal.ts
+++ b/server/src/models/Proposal.ts
@@ -1,0 +1,15 @@
+import { Schema, model, Types } from 'mongoose';
+
+export interface Proposal {
+  tenantId: Types.ObjectId;
+  projectId: Types.ObjectId;
+}
+
+const ProposalSchema = new Schema<Proposal>({
+  tenantId: { type: Schema.Types.ObjectId, required: true },
+  projectId: { type: Schema.Types.ObjectId, required: true },
+});
+
+ProposalSchema.index({ tenantId: 1, projectId: 1 });
+
+export default model<Proposal>('Proposal', ProposalSchema);

--- a/server/src/models/Rep.ts
+++ b/server/src/models/Rep.ts
@@ -1,0 +1,15 @@
+import { Schema, model, Types } from 'mongoose';
+
+export interface Rep {
+  tenantId: Types.ObjectId;
+  email: string;
+}
+
+const RepSchema = new Schema<Rep>({
+  tenantId: { type: Schema.Types.ObjectId, required: true },
+  email: { type: String, required: true },
+});
+
+RepSchema.index({ tenantId: 1, email: 1 });
+
+export default model<Rep>('Rep', RepSchema);

--- a/server/src/models/StandardStep.ts
+++ b/server/src/models/StandardStep.ts
@@ -1,0 +1,15 @@
+import { Schema, model, Types } from 'mongoose';
+
+export interface StandardStep {
+  tenantId: Types.ObjectId;
+  name: string;
+}
+
+const StandardStepSchema = new Schema<StandardStep>({
+  tenantId: { type: Schema.Types.ObjectId, required: true },
+  name: { type: String, required: true },
+});
+
+StandardStepSchema.index({ tenantId: 1, name: 1 });
+
+export default model<StandardStep>('StandardStep', StandardStepSchema);

--- a/server/src/models/Step.ts
+++ b/server/src/models/Step.ts
@@ -1,0 +1,15 @@
+import { Schema, model, Types } from 'mongoose';
+
+export interface Step {
+  tenantId: Types.ObjectId;
+  projectId: Types.ObjectId;
+}
+
+const StepSchema = new Schema<Step>({
+  tenantId: { type: Schema.Types.ObjectId, required: true },
+  projectId: { type: Schema.Types.ObjectId, required: true },
+});
+
+StepSchema.index({ tenantId: 1, projectId: 1 });
+
+export default model<Step>('Step', StepSchema);

--- a/server/src/models/SummerTime.ts
+++ b/server/src/models/SummerTime.ts
@@ -1,0 +1,15 @@
+import { Schema, model, Types } from 'mongoose';
+
+export interface SummerTime {
+  tenantId: Types.ObjectId;
+  year: number;
+}
+
+const SummerTimeSchema = new Schema<SummerTime>({
+  tenantId: { type: Schema.Types.ObjectId, required: true },
+  year: { type: Number, required: true },
+});
+
+SummerTimeSchema.index({ tenantId: 1, year: 1 });
+
+export default model<SummerTime>('SummerTime', SummerTimeSchema);

--- a/server/src/models/Tenant.ts
+++ b/server/src/models/Tenant.ts
@@ -1,0 +1,15 @@
+import { Schema, model, Types } from 'mongoose';
+
+export interface Tenant {
+  tenantId: Types.ObjectId;
+  name: string;
+}
+
+const TenantSchema = new Schema<Tenant>({
+  tenantId: { type: Schema.Types.ObjectId, required: true },
+  name: { type: String, required: true },
+});
+
+TenantSchema.index({ tenantId: 1, name: 1 });
+
+export default model<Tenant>('Tenant', TenantSchema);

--- a/server/src/models/User.ts
+++ b/server/src/models/User.ts
@@ -1,0 +1,15 @@
+import { Schema, model, Types } from 'mongoose';
+
+export interface User {
+  tenantId: Types.ObjectId;
+  email: string;
+}
+
+const UserSchema = new Schema<User>({
+  tenantId: { type: Schema.Types.ObjectId, required: true },
+  email: { type: String, required: true },
+});
+
+UserSchema.index({ tenantId: 1, email: 1 });
+
+export default model<User>('User', UserSchema);

--- a/server/src/models/Variation.ts
+++ b/server/src/models/Variation.ts
@@ -1,0 +1,15 @@
+import { Schema, model, Types } from 'mongoose';
+
+export interface Variation {
+  tenantId: Types.ObjectId;
+  proposalId: Types.ObjectId;
+}
+
+const VariationSchema = new Schema<Variation>({
+  tenantId: { type: Schema.Types.ObjectId, required: true },
+  proposalId: { type: Schema.Types.ObjectId, required: true },
+});
+
+VariationSchema.index({ tenantId: 1, proposalId: 1 });
+
+export default model<Variation>('Variation', VariationSchema);


### PR DESCRIPTION
## Summary
- add Mongoose schemas for Tenant, User, Membership, Customer, Project, Step, PriceList, Proposal, Variation, EmailMsg, Document, Rep, Council, StandardStep, SummerTime and AuditLog
- each schema includes tenantId and a compound tenant index

## Testing
- `npm run lint`
- `npm run build:server`


------
https://chatgpt.com/codex/tasks/task_e_689ee6848710832686462d701782966c