### PR TITLE
feat: add tenant-aware routers

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "react-dom": "18.3.1",
     "react-perfect-scrollbar": "1.5.8",
     "react-use": "17.6.0",
-    "server-only": "0.0.1"
+    "server-only": "0.0.1",
+    "zod": "^4.0.17"
   },
   "devDependencies": {
     "@iconify/json": "2.2.286",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       server-only:
         specifier: 0.0.1
         version: 0.0.1
+      zod:
+        specifier: ^4.0.17
+        version: 4.0.17
     devDependencies:
       '@iconify/json':
         specifier: 2.2.286
@@ -3382,6 +3385,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@4.0.17:
+    resolution: {integrity: sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==}
 
 snapshots:
 
@@ -6985,3 +6991,5 @@ snapshots:
       fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
+
+  zod@4.0.17: {}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -1,6 +1,33 @@
 import { Router } from 'express';
+import auth from '../src/routes/auth';
+import tenants from '../src/routes/tenants';
+import users from '../src/routes/users';
+import memberships from '../src/routes/memberships';
+import customers from '../src/routes/customers';
+import projects from '../src/routes/projects';
+import steps from '../src/routes/steps';
+import priceLists from '../src/routes/priceLists';
+import proposals from '../src/routes/proposals';
+import variations from '../src/routes/variations';
+import emails from '../src/routes/emails';
+import templates from '../src/routes/templates';
+import admin from '../src/routes/admin';
 
 const router = Router();
+
+router.use('/auth', auth);
+router.use('/tenants', tenants);
+router.use('/users', users);
+router.use('/memberships', memberships);
+router.use('/customers', customers);
+router.use('/projects', projects);
+router.use('/steps', steps);
+router.use('/price-lists', priceLists);
+router.use('/proposals', proposals);
+router.use('/variations', variations);
+router.use('/emails', emails);
+router.use('/templates', templates);
+router.use('/admin', admin);
 
 router.get('/health', (_req, res) => {
   res.send('ok');

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import Council from '../models/Council';
+import { createTenantRouter } from './crud';
+
+const schema = z.object({
+  name: z.string(),
+});
+
+export default createTenantRouter('admin-tables', Council, schema);

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,0 +1,21 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { signTenantToken } from '../auth/jwt';
+
+const router = Router();
+
+const loginSchema = z.object({
+  tenantId: z.string(),
+  userId: z.string(),
+});
+
+router.post('/login', (req, res) => {
+  const parsed = loginSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json(parsed.error.flatten());
+  }
+  const token = signTenantToken(parsed.data.tenantId, parsed.data.userId);
+  res.json({ token });
+});
+
+export default router;

--- a/server/src/routes/crud.ts
+++ b/server/src/routes/crud.ts
@@ -1,0 +1,56 @@
+import { Router } from 'express';
+import { Model } from 'mongoose';
+import { ZodObject } from 'zod';
+import { guard, AuthenticatedRequest } from '../auth/guard';
+import AuditLog from '../models/AuditLog';
+
+export function createTenantRouter(
+  resource: string,
+  model: Model<any>,
+  schema: ZodObject<any>
+) {
+  const router = Router();
+
+  router.get('/', guard(resource, 'read'), async (req: AuthenticatedRequest, res) => {
+    const items = await model.find({ tenantId: req.tenantId }).lean();
+    res.json(items);
+  });
+
+  router.post('/', guard(resource, 'create'), async (req: AuthenticatedRequest, res) => {
+    const parsed = schema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json(parsed.error.flatten());
+    }
+    const created = await model.create({ ...parsed.data, tenantId: req.tenantId });
+    await AuditLog.create({ tenantId: req.tenantId!, createdAt: new Date() });
+    res.status(201).json(created);
+  });
+
+  router.put('/:id', guard(resource, 'update'), async (req: AuthenticatedRequest, res) => {
+    const parsed = schema.partial().safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json(parsed.error.flatten());
+    }
+    const updated = await model.findOneAndUpdate(
+      { _id: req.params.id, tenantId: req.tenantId },
+      parsed.data,
+      { new: true }
+    );
+    if (!updated) {
+      return res.status(404).json({ message: 'Not found' });
+    }
+    await AuditLog.create({ tenantId: req.tenantId!, createdAt: new Date() });
+    res.json(updated);
+  });
+
+  router.delete('/:id', guard(resource, 'delete'), async (req: AuthenticatedRequest, res) => {
+    const deleted = await model.findOneAndDelete({ _id: req.params.id, tenantId: req.tenantId });
+    if (!deleted) {
+      return res.status(404).json({ message: 'Not found' });
+    }
+    await AuditLog.create({ tenantId: req.tenantId!, createdAt: new Date() });
+    res.status(204).send();
+  });
+
+  return router;
+}

--- a/server/src/routes/customers.ts
+++ b/server/src/routes/customers.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import Customer from '../models/Customer';
+import { createTenantRouter } from './crud';
+
+const schema = z.object({
+  email: z.string().email(),
+});
+
+export default createTenantRouter('customers', Customer, schema);

--- a/server/src/routes/emails.ts
+++ b/server/src/routes/emails.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import EmailMsg from '../models/EmailMsg';
+import { createTenantRouter } from './crud';
+
+const schema = z.object({
+  messageId: z.string(),
+});
+
+export default createTenantRouter('emails', EmailMsg, schema);

--- a/server/src/routes/memberships.ts
+++ b/server/src/routes/memberships.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+import Membership from '../models/Membership';
+import { createTenantRouter } from './crud';
+
+const schema = z.object({
+  userId: z.string(),
+  role: z.enum(['admin', 'member']),
+});
+
+export default createTenantRouter('memberships', Membership, schema);

--- a/server/src/routes/priceLists.ts
+++ b/server/src/routes/priceLists.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import PriceList from '../models/PriceList';
+import { createTenantRouter } from './crud';
+
+const schema = z.object({
+  name: z.string(),
+});
+
+export default createTenantRouter('price-lists', PriceList, schema);

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import Project from '../models/Project';
+import { createTenantRouter } from './crud';
+
+const schema = z.object({
+  name: z.string(),
+});
+
+export default createTenantRouter('projects', Project, schema);

--- a/server/src/routes/proposals.ts
+++ b/server/src/routes/proposals.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import Proposal from '../models/Proposal';
+import { createTenantRouter } from './crud';
+
+const schema = z.object({
+  projectId: z.string(),
+});
+
+export default createTenantRouter('proposals', Proposal, schema);

--- a/server/src/routes/steps.ts
+++ b/server/src/routes/steps.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import Step from '../models/Step';
+import { createTenantRouter } from './crud';
+
+const schema = z.object({
+  projectId: z.string(),
+});
+
+export default createTenantRouter('steps', Step, schema);

--- a/server/src/routes/templates.ts
+++ b/server/src/routes/templates.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import Document from '../models/Document';
+import { createTenantRouter } from './crud';
+
+const schema = z.object({
+  title: z.string(),
+});
+
+export default createTenantRouter('templates', Document, schema);

--- a/server/src/routes/tenants.ts
+++ b/server/src/routes/tenants.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import Tenant from '../models/Tenant';
+import { createTenantRouter } from './crud';
+
+const schema = z.object({
+  name: z.string(),
+});
+
+export default createTenantRouter('tenants', Tenant, schema);

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import User from '../models/User';
+import { createTenantRouter } from './crud';
+
+const schema = z.object({
+  email: z.string().email(),
+});
+
+export default createTenantRouter('users', User, schema);

--- a/server/src/routes/variations.ts
+++ b/server/src/routes/variations.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import Variation from '../models/Variation';
+import { createTenantRouter } from './crud';
+
+const schema = z.object({
+  proposalId: z.string(),
+});
+
+export default createTenantRouter('variations', Variation, schema);


### PR DESCRIPTION
## Summary
- add auth and CRUD routers for core entities with tenant scoping
- validate requests using Zod and log mutations to AuditLog
- wire new routers into server API and add zod dependency

## Testing
- `npm run build:server`

------
https://chatgpt.com/codex/tasks/task_e_689ee9894eb08326962208df8b5d5fe6