### PR TITLE
feat: add seed scripts

### DIFF
--- a/scripts/seed-councils.ts
+++ b/scripts/seed-councils.ts
@@ -1,0 +1,32 @@
+import dotenv from 'dotenv'
+import mongoose, { Types } from 'mongoose'
+import Council from '../server/src/models/Council'
+
+dotenv.config()
+
+async function seed(tenantId: string) {
+  const id = new Types.ObjectId(tenantId)
+  const councils = ['Council A', 'Council B']
+
+  await Council.deleteMany({ tenantId: id })
+  await Council.insertMany(councils.map(name => ({ tenantId: id, name })))
+  console.log('Councils seeded')
+}
+
+async function run() {
+  const [, , tenantId] = process.argv
+  if (!tenantId) {
+    console.error('Usage: tsx scripts/seed-councils.ts <tenantId>')
+    process.exit(1)
+  }
+
+  const mongoUrl = process.env.MONGO_URL || 'mongodb://localhost:27017/test'
+  await mongoose.connect(mongoUrl)
+  await seed(tenantId)
+  await mongoose.disconnect()
+}
+
+run().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/seed-price-list.ts
+++ b/scripts/seed-price-list.ts
@@ -1,0 +1,32 @@
+import dotenv from 'dotenv'
+import mongoose, { Types } from 'mongoose'
+import PriceList from '../server/src/models/PriceList'
+
+dotenv.config()
+
+async function seed(tenantId: string) {
+  const id = new Types.ObjectId(tenantId)
+  const lists = ['Default', 'Premium']
+
+  await PriceList.deleteMany({ tenantId: id })
+  await PriceList.insertMany(lists.map(name => ({ tenantId: id, name })))
+  console.log('Price lists seeded')
+}
+
+async function run() {
+  const [, , tenantId] = process.argv
+  if (!tenantId) {
+    console.error('Usage: tsx scripts/seed-price-list.ts <tenantId>')
+    process.exit(1)
+  }
+
+  const mongoUrl = process.env.MONGO_URL || 'mongodb://localhost:27017/test'
+  await mongoose.connect(mongoUrl)
+  await seed(tenantId)
+  await mongoose.disconnect()
+}
+
+run().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/seed-reps.ts
+++ b/scripts/seed-reps.ts
@@ -1,0 +1,32 @@
+import dotenv from 'dotenv'
+import mongoose, { Types } from 'mongoose'
+import Rep from '../server/src/models/Rep'
+
+dotenv.config()
+
+async function seed(tenantId: string) {
+  const id = new Types.ObjectId(tenantId)
+  const reps = ['rep1@example.com', 'rep2@example.com']
+
+  await Rep.deleteMany({ tenantId: id })
+  await Rep.insertMany(reps.map(email => ({ tenantId: id, email })))
+  console.log('Reps seeded')
+}
+
+async function run() {
+  const [, , tenantId] = process.argv
+  if (!tenantId) {
+    console.error('Usage: tsx scripts/seed-reps.ts <tenantId>')
+    process.exit(1)
+  }
+
+  const mongoUrl = process.env.MONGO_URL || 'mongodb://localhost:27017/test'
+  await mongoose.connect(mongoUrl)
+  await seed(tenantId)
+  await mongoose.disconnect()
+}
+
+run().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/seed-standard-steps.ts
+++ b/scripts/seed-standard-steps.ts
@@ -1,0 +1,32 @@
+import dotenv from 'dotenv'
+import mongoose, { Types } from 'mongoose'
+import StandardStep from '../server/src/models/StandardStep'
+
+dotenv.config()
+
+async function seed(tenantId: string) {
+  const id = new Types.ObjectId(tenantId)
+  const steps = ['Pre-Construction', 'Construction', 'Post-Construction']
+
+  await StandardStep.deleteMany({ tenantId: id })
+  await StandardStep.insertMany(steps.map(name => ({ tenantId: id, name })))
+  console.log('Standard steps seeded')
+}
+
+async function run() {
+  const [, , tenantId] = process.argv
+  if (!tenantId) {
+    console.error('Usage: tsx scripts/seed-standard-steps.ts <tenantId>')
+    process.exit(1)
+  }
+
+  const mongoUrl = process.env.MONGO_URL || 'mongodb://localhost:27017/test'
+  await mongoose.connect(mongoUrl)
+  await seed(tenantId)
+  await mongoose.disconnect()
+}
+
+run().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/seed-summer-times.ts
+++ b/scripts/seed-summer-times.ts
@@ -1,0 +1,32 @@
+import dotenv from 'dotenv'
+import mongoose, { Types } from 'mongoose'
+import SummerTime from '../server/src/models/SummerTime'
+
+dotenv.config()
+
+async function seed(tenantId: string) {
+  const id = new Types.ObjectId(tenantId)
+  const years = [2024, 2025]
+
+  await SummerTime.deleteMany({ tenantId: id })
+  await SummerTime.insertMany(years.map(year => ({ tenantId: id, year })))
+  console.log('Summer times seeded')
+}
+
+async function run() {
+  const [, , tenantId] = process.argv
+  if (!tenantId) {
+    console.error('Usage: tsx scripts/seed-summer-times.ts <tenantId>')
+    process.exit(1)
+  }
+
+  const mongoUrl = process.env.MONGO_URL || 'mongodb://localhost:27017/test'
+  await mongoose.connect(mongoUrl)
+  await seed(tenantId)
+  await mongoose.disconnect()
+}
+
+run().catch(err => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- add seed scripts for standard steps, councils, summer times, reps, and price lists
- each script connects to MongoDB and seeds default data for a given tenant ID

## Testing
- `npm run lint`
- `npx tsx scripts/seed-standard-steps.ts 507f1f77bcf86cd799439011` *(fails: connect ECONNREFUSED ::1:27017)*

------
https://chatgpt.com/codex/tasks/task_e_689eef185d688326a14b4ffcf52a6035