### PR TITLE
Add projects page with drawer form

### DIFF
--- a/src/app/(dashboard)/projects/ProjectDrawer.tsx
+++ b/src/app/(dashboard)/projects/ProjectDrawer.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import { useState } from 'react'
+
+// MUI Imports
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Drawer from '@mui/material/Drawer'
+import Grid from '@mui/material/Grid'
+import Tab from '@mui/material/Tab'
+import Typography from '@mui/material/Typography'
+import TabContext from '@mui/lab/TabContext'
+import TabPanel from '@mui/lab/TabPanel'
+
+// Custom Component Imports
+import CustomTextField from '@core/components/mui/TextField'
+import TabList from '@core/components/mui/TabList'
+
+interface ProjectDrawerProps {
+  open: boolean
+  onClose: () => void
+}
+
+const ProjectDrawer = ({ open, onClose }: ProjectDrawerProps) => {
+  const [tab, setTab] = useState('steps')
+  const [name, setName] = useState('')
+  const [steps, setSteps] = useState<string[]>([''])
+
+  const handleStepChange = (index: number, value: string) => {
+    setSteps(prev => prev.map((step, i) => (i === index ? value : step)))
+  }
+
+  const addStep = () => {
+    setSteps(prev => [...prev, ''])
+  }
+
+  const handleSave = () => {
+    onClose()
+  }
+
+  return (
+    <Drawer anchor='right' open={open} onClose={onClose} keepMounted>
+      <Box className='flex flex-col gap-4 p-6 is-[400px]'>
+        <Typography variant='h6'>New Project</Typography>
+        <CustomTextField
+          fullWidth
+          label='Project Name'
+          value={name}
+          onChange={e => setName(e.target.value)}
+          required
+        />
+
+        <TabContext value={tab}>
+          <TabList onChange={(e, value) => setTab(value)} aria-label='project tabs'>
+            <Tab value='steps' label='Steps' />
+            <Tab value='preview' label='Reminder Preview' />
+          </TabList>
+          <TabPanel value='steps'>
+            <Grid container spacing={2}>
+              {steps.map((step, index) => (
+                <Grid item xs={12} key={index}>
+                  <CustomTextField
+                    fullWidth
+                    label={`Step ${index + 1}`}
+                    value={step}
+                    onChange={e => handleStepChange(index, e.target.value)}
+                  />
+                </Grid>
+              ))}
+              <Grid item xs={12}>
+                <Button size='small' variant='outlined' onClick={addStep}>
+                  Add Step
+                </Button>
+              </Grid>
+            </Grid>
+          </TabPanel>
+          <TabPanel value='preview'>
+            <Typography variant='body2'>Reminder preview:</Typography>
+            <ul className='list-disc ms-4'>
+              {steps.filter(step => step).map((step, idx) => (
+                <li key={idx}>{step}</li>
+              ))}
+            </ul>
+          </TabPanel>
+        </TabContext>
+
+        <Box className='flex justify-end gap-2 mt-4'>
+          <Button variant='tonal' color='secondary' onClick={onClose}>
+            Cancel
+          </Button>
+          <Button variant='contained' disabled={!name} onClick={handleSave}>
+            Save
+          </Button>
+        </Box>
+      </Box>
+    </Drawer>
+  )
+}
+
+export default ProjectDrawer
+

--- a/src/app/(dashboard)/projects/page.tsx
+++ b/src/app/(dashboard)/projects/page.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { useState } from 'react'
+
+// MUI Imports
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import MenuItem from '@mui/material/MenuItem'
+import Paper from '@mui/material/Paper'
+import Table from '@mui/material/Table'
+import TableBody from '@mui/material/TableBody'
+import TableCell from '@mui/material/TableCell'
+import TableContainer from '@mui/material/TableContainer'
+import TableHead from '@mui/material/TableHead'
+import TableRow from '@mui/material/TableRow'
+
+// Custom Component Imports
+import CustomTextField from '@core/components/mui/TextField'
+
+// Local Component Imports
+import ProjectDrawer from './ProjectDrawer'
+
+interface Project {
+  id: number
+  name: string
+  status: 'Active' | 'Archived'
+}
+
+const initialData: Project[] = [
+  { id: 1, name: 'Website Redesign', status: 'Active' },
+  { id: 2, name: 'Mobile App', status: 'Archived' }
+]
+
+const Page = () => {
+  const [search, setSearch] = useState('')
+  const [statusFilter, setStatusFilter] = useState<'All' | 'Active' | 'Archived'>('All')
+  const [open, setOpen] = useState(false)
+
+  const filtered = initialData.filter(project => {
+    const matchesSearch = project.name.toLowerCase().includes(search.toLowerCase())
+    const matchesStatus = statusFilter === 'All' || project.status === statusFilter
+    
+    return matchesSearch && matchesStatus
+  })
+
+  return (
+    <Box className='flex flex-col gap-4'>
+      <Box className='flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between'>
+        <Box className='flex gap-2'>
+          <CustomTextField
+            placeholder='Search projects'
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+          />
+          <CustomTextField
+            select
+            value={statusFilter}
+            onChange={e => setStatusFilter(e.target.value as any)}
+            sx={{ minWidth: 120 }}
+          >
+            <MenuItem value='All'>All</MenuItem>
+            <MenuItem value='Active'>Active</MenuItem>
+            <MenuItem value='Archived'>Archived</MenuItem>
+          </CustomTextField>
+        </Box>
+        <Button variant='contained' onClick={() => setOpen(true)}>
+          New Project
+        </Button>
+      </Box>
+
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Name</TableCell>
+              <TableCell>Status</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {filtered.map(project => (
+              <TableRow key={project.id} hover>
+                <TableCell>{project.name}</TableCell>
+                <TableCell>{project.status}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <ProjectDrawer open={open} onClose={() => setOpen(false)} />
+    </Box>
+  )
+}
+
+export default Page
+


### PR DESCRIPTION
## Summary
- add projects dashboard page with search, filters, and new project action
- introduce ProjectDrawer form with step editing and reminder preview

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f00ac5f188326b51e2c9d766299ac