### PR TITLE
Add proposal builder components with totals and adjustments

### DIFF
--- a/src/app/(dashboard)/proposals/[id]/RowEditor.tsx
+++ b/src/app/(dashboard)/proposals/[id]/RowEditor.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import TableRow from '@mui/material/TableRow'
+import TableCell from '@mui/material/TableCell'
+import Checkbox from '@mui/material/Checkbox'
+
+import CustomTextField from '@core/components/mui/TextField'
+
+interface ProposalItem {
+  id: number
+  name: string
+  qty: number
+  price: number
+  optional?: boolean
+  selected?: boolean
+}
+
+interface RowEditorProps {
+  item: ProposalItem
+  showPrices: boolean
+  onChange: (item: ProposalItem) => void
+}
+
+const RowEditor = ({ item, showPrices, onChange }: RowEditorProps) => {
+  const handleChange = (key: keyof ProposalItem, value: any) => {
+    onChange({ ...item, [key]: value })
+  }
+
+  return (
+    <TableRow>
+      <TableCell>
+        {item.optional && (
+          <Checkbox
+            checked={item.selected ?? false}
+            onChange={e => handleChange('selected', e.target.checked)}
+          />
+        )}
+      </TableCell>
+      <TableCell>
+        <CustomTextField value={item.name} onChange={e => handleChange('name', e.target.value)} fullWidth />
+      </TableCell>
+      <TableCell>
+        <CustomTextField
+          type='number'
+          value={item.qty}
+          onChange={e => handleChange('qty', Number(e.target.value))}
+          sx={{ width: 80 }}
+        />
+      </TableCell>
+      {showPrices && (
+        <>
+          <TableCell>
+            <CustomTextField
+              type='number'
+              value={item.price}
+              onChange={e => handleChange('price', Number(e.target.value))}
+              sx={{ width: 100 }}
+            />
+          </TableCell>
+          <TableCell>{(item.qty * item.price).toFixed(2)}</TableCell>
+        </>
+      )}
+    </TableRow>
+  )
+}
+
+export default RowEditor
+

--- a/src/app/(dashboard)/proposals/[id]/SectionCard.tsx
+++ b/src/app/(dashboard)/proposals/[id]/SectionCard.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import Card from '@mui/material/Card'
+import CardHeader from '@mui/material/CardHeader'
+import CardContent from '@mui/material/CardContent'
+import Table from '@mui/material/Table'
+import TableBody from '@mui/material/TableBody'
+import TableCell from '@mui/material/TableCell'
+import TableHead from '@mui/material/TableHead'
+import TableRow from '@mui/material/TableRow'
+import Switch from '@mui/material/Switch'
+import FormControlLabel from '@mui/material/FormControlLabel'
+
+import RowEditor from './RowEditor'
+
+interface ProposalItem {
+  id: number
+  name: string
+  qty: number
+  price: number
+  optional?: boolean
+  selected?: boolean
+}
+
+interface ProposalSection {
+  id: number
+  title: string
+  complete: boolean
+  items: ProposalItem[]
+}
+
+interface SectionCardProps {
+  section: ProposalSection
+  showPrices: boolean
+  find: string
+  onChange: (section: ProposalSection) => void
+}
+
+const SectionCard = ({ section, showPrices, find, onChange }: SectionCardProps) => {
+  const handleItemChange = (item: ProposalItem) => {
+    const items = section.items.map(i => (i.id === item.id ? item : i))
+
+    onChange({ ...section, items })
+  }
+
+  const filtered = section.items.filter(item => item.name.toLowerCase().includes(find.toLowerCase()))
+
+  return (
+    <Card>
+      <CardHeader
+        title={section.title}
+        action={
+          <FormControlLabel
+            control={<Switch checked={section.complete} onChange={e => onChange({ ...section, complete: e.target.checked })} />}
+            label='Complete'
+          />
+        }
+      />
+      <CardContent>
+        <Table size='small'>
+          <TableHead>
+            <TableRow>
+              <TableCell width={50}></TableCell>
+              <TableCell>Name</TableCell>
+              <TableCell width={80}>Qty</TableCell>
+              {showPrices && (
+                <>
+                  <TableCell width={100}>Price</TableCell>
+                  <TableCell width={100}>Total</TableCell>
+                </>
+              )}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {filtered.map(item => (
+              <RowEditor key={item.id} item={item} showPrices={showPrices} onChange={handleItemChange} />
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default SectionCard
+

--- a/src/app/(dashboard)/proposals/[id]/TotalsBar.tsx
+++ b/src/app/(dashboard)/proposals/[id]/TotalsBar.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import Box from '@mui/material/Box'
+import Switch from '@mui/material/Switch'
+import FormControlLabel from '@mui/material/FormControlLabel'
+
+import CustomTextField from '@core/components/mui/TextField'
+
+interface ProposalItem {
+  id: number
+  name: string
+  qty: number
+  price: number
+  optional?: boolean
+  selected?: boolean
+}
+
+interface ProposalSection {
+  id: number
+  title: string
+  complete: boolean
+  items: ProposalItem[]
+}
+
+interface TotalsBarProps {
+  sections: ProposalSection[]
+  showPrices: boolean
+  onShowPricesChange: (value: boolean) => void
+  adjustment: number
+  onAdjustmentChange: (value: number) => void
+}
+
+const TotalsBar = ({ sections, showPrices, onShowPricesChange, adjustment, onAdjustmentChange }: TotalsBarProps) => {
+  const subtotal = sections.reduce((sum, section) => {
+    return (
+      sum +
+      section.items.reduce((s, item) => {
+        if (item.optional && !item.selected) return s
+
+        return s + item.qty * item.price
+      }, 0)
+    )
+  }, 0)
+
+  const total = subtotal + adjustment
+
+  return (
+    <Box className='flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-end'>
+      <FormControlLabel
+        control={<Switch checked={showPrices} onChange={e => onShowPricesChange(e.target.checked)} />}
+        label='Show Prices'
+      />
+      {showPrices && (
+        <>
+          <Box className='flex items-center gap-2'>
+            <span>Adjustment</span>
+            <CustomTextField
+              type='number'
+              value={adjustment}
+              onChange={e => onAdjustmentChange(Number(e.target.value))}
+              sx={{ width: 120 }}
+            />
+          </Box>
+          <Box className='text-right'>
+            <div>Subtotal: {subtotal.toFixed(2)}</div>
+            <div>Total: {total.toFixed(2)}</div>
+          </Box>
+        </>
+      )}
+    </Box>
+  )
+}
+
+export default TotalsBar
+

--- a/src/app/(dashboard)/proposals/[id]/page.tsx
+++ b/src/app/(dashboard)/proposals/[id]/page.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { useState } from 'react'
+
+// MUI Imports
+import Box from '@mui/material/Box'
+
+// Custom Components
+import CustomTextField from '@core/components/mui/TextField'
+
+// Local Components
+import SectionCard from './SectionCard'
+import TotalsBar from './TotalsBar'
+
+interface ProposalItem {
+  id: number
+  name: string
+  qty: number
+  price: number
+  optional?: boolean
+  selected?: boolean
+}
+
+interface ProposalSection {
+  id: number
+  title: string
+  complete: boolean
+  items: ProposalItem[]
+}
+
+const initialSections: ProposalSection[] = [
+  {
+    id: 1,
+    title: 'General',
+    complete: false,
+    items: [
+      { id: 1, name: 'Item A', qty: 1, price: 100 },
+      { id: 2, name: 'Item B', qty: 2, price: 50, optional: true, selected: false }
+    ]
+  },
+  {
+    id: 2,
+    title: 'Extras',
+    complete: false,
+    items: [
+      { id: 3, name: 'Item C', qty: 3, price: 75 },
+      { id: 4, name: 'Item D', qty: 1, price: 200, optional: true, selected: true }
+    ]
+  }
+]
+
+const Page = () => {
+  const [sections, setSections] = useState<ProposalSection[]>(initialSections)
+  const [showPrices, setShowPrices] = useState(true)
+  const [adjustment, setAdjustment] = useState(0)
+  const [find, setFind] = useState('')
+
+  const handleSectionChange = (section: ProposalSection) => {
+    setSections(prev => prev.map(s => (s.id === section.id ? section : s)))
+  }
+
+  return (
+    <Box className='flex flex-col gap-4'>
+      <CustomTextField
+        placeholder='Find'
+        value={find}
+        onChange={e => setFind(e.target.value)}
+        fullWidth
+      />
+      {sections.map(section => (
+        <SectionCard
+          key={section.id}
+          section={section}
+          showPrices={showPrices}
+          find={find}
+          onChange={handleSectionChange}
+        />
+      ))}
+      <TotalsBar
+        sections={sections}
+        showPrices={showPrices}
+        onShowPricesChange={setShowPrices}
+        adjustment={adjustment}
+        onAdjustmentChange={setAdjustment}
+      />
+    </Box>
+  )
+}
+
+export default Page
+


### PR DESCRIPTION
## Summary
- add proposal detail page with search and adjustable sections
- support optional items, section completion, and price visibility toggle
- include totals bar with adjustments and auto-calculated totals

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_689f023e98108326ab62f7d91fdbce77