### PR TITLE
Add API, auth, RBAC, and format utilities

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,56 @@
+import { getToken } from './auth'
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000'
+
+type RequestOptions = RequestInit & {
+  params?: Record<string, unknown>
+}
+
+const buildQuery = (params?: Record<string, unknown>) => {
+  if (!params) return ''
+
+  const query = new URLSearchParams()
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) query.append(key, String(value))
+  })
+
+  const queryString = query.toString()
+
+  return queryString ? `?${queryString}` : ''
+}
+
+const request = async <T>(endpoint: string, options: RequestOptions = {}): Promise<T> => {
+  const { params, headers, ...init } = options
+
+  const token = getToken()
+
+  const fetchHeaders: HeadersInit = {
+    'Content-Type': 'application/json',
+    ...headers,
+  }
+
+  if (token) fetchHeaders['Authorization'] = `Bearer ${token}`
+
+  const res = await fetch(`${API_BASE_URL}${endpoint}${buildQuery(params)}`, {
+    ...init,
+    headers: fetchHeaders,
+  })
+
+  if (!res.ok) {
+    throw new Error(await res.text())
+  }
+
+  return (await res.json()) as T
+}
+
+export const api = {
+  get: <T>(url: string, options?: RequestOptions) => request<T>(url, { ...options, method: 'GET' }),
+  post: <T>(url: string, body?: unknown, options?: RequestOptions) =>
+    request<T>(url, { ...options, method: 'POST', body: JSON.stringify(body) }),
+  put: <T>(url: string, body?: unknown, options?: RequestOptions) =>
+    request<T>(url, { ...options, method: 'PUT', body: JSON.stringify(body) }),
+  del: <T>(url: string, options?: RequestOptions) => request<T>(url, { ...options, method: 'DELETE' }),
+}
+
+export default api

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,21 @@
+const TOKEN_KEY = 'accessToken'
+
+export const getToken = () => {
+  if (typeof window === 'undefined') return null
+
+  return localStorage.getItem(TOKEN_KEY)
+}
+
+export const setToken = (token: string) => {
+  if (typeof window === 'undefined') return
+
+  localStorage.setItem(TOKEN_KEY, token)
+}
+
+export const removeToken = () => {
+  if (typeof window === 'undefined') return
+
+  localStorage.removeItem(TOKEN_KEY)
+}
+
+export const isAuthenticated = () => !!getToken()

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,11 @@
+export const formatCurrency = (
+  value: number,
+  currency = 'USD',
+  locale = 'en-US'
+) => new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value)
+
+export const formatDate = (
+  value: Date | number | string,
+  locale = 'en-US',
+  options?: Intl.DateTimeFormatOptions
+) => new Intl.DateTimeFormat(locale, options).format(new Date(value))

--- a/src/utils/rbac.ts
+++ b/src/utils/rbac.ts
@@ -1,0 +1,11 @@
+export const hasRole = (userRoles: string[], required: string | string[]) => {
+  const requiredRoles = Array.isArray(required) ? required : [required]
+
+  return requiredRoles.some(role => userRoles.includes(role))
+}
+
+export const hasPermission = (userPermissions: string[], required: string | string[]) => {
+  const requiredPerms = Array.isArray(required) ? required : [required]
+
+  return requiredPerms.some(permission => userPermissions.includes(permission))
+}


### PR DESCRIPTION
## Summary
- add fetch-based API helper with token support
- add localStorage token utilities
- implement role/permission checks
- add currency and date formatting helpers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689f0801352c8326b6bf53f0ebef22b3