### PR TITLE
docs: expand swagger schemas

### DIFF
--- a/server/src/config/swagger.ts
+++ b/server/src/config/swagger.ts
@@ -7,6 +7,42 @@ const options = {
       title: 'API Documentation',
       version: '1.0.0',
     },
+    components: {
+      schemas: {
+        Customer: {
+          type: 'object',
+          required: ['tenantId', 'email'],
+          properties: {
+            tenantId: {
+              type: 'string',
+              description: 'Tenant identifier',
+              example: '507f1f77bcf86cd799439011',
+            },
+            email: {
+              type: 'string',
+              description: 'Customer email',
+              example: 'john@example.com',
+            },
+          },
+        },
+        Project: {
+          type: 'object',
+          required: ['tenantId', 'name'],
+          properties: {
+            tenantId: {
+              type: 'string',
+              description: 'Tenant identifier',
+              example: '507f1f77bcf86cd799439011',
+            },
+            name: {
+              type: 'string',
+              description: 'Project name',
+              example: 'Project Alpha',
+            },
+          },
+        },
+      },
+    },
   },
   apis: ['server/src/routes/*.ts'],
 };

--- a/server/src/routes/customers.ts
+++ b/server/src/routes/customers.ts
@@ -11,12 +11,73 @@ const schema = z.object({
  * /customers:
  *   get:
  *     summary: List customers.
+ *     responses:
+ *       '200':
+ *         description: Customers fetched.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Customer'
+ *             example:
+ *               - tenantId: '507f1f77bcf86cd799439011'
+ *                 email: 'john@example.com'
  *   post:
  *     summary: Create a customer.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Customer'
+ *           example:
+ *             tenantId: '507f1f77bcf86cd799439011'
+ *             email: 'john@example.com'
+ *     responses:
+ *       '200':
+ *         description: Customer created.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Customer'
+ *             example:
+ *               tenantId: '507f1f77bcf86cd799439011'
+ *               email: 'john@example.com'
  * /customers/{id}:
  *   put:
  *     summary: Update a customer.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Customer'
+ *           example:
+ *             tenantId: '507f1f77bcf86cd799439011'
+ *             email: 'jane@example.com'
+ *     responses:
+ *       '200':
+ *         description: Customer updated.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Customer'
+ *             example:
+ *               tenantId: '507f1f77bcf86cd799439011'
+ *               email: 'jane@example.com'
  *   delete:
  *     summary: Delete a customer.
+ *     responses:
+ *       '200':
+ *         description: Customer deleted.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
  */
 export default createTenantRouter('customers', Customer, schema);

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -11,12 +11,73 @@ const schema = z.object({
  * /projects:
  *   get:
  *     summary: List projects.
+ *     responses:
+ *       '200':
+ *         description: Projects fetched.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Project'
+ *             example:
+ *               - tenantId: '507f1f77bcf86cd799439011'
+ *                 name: 'Project Alpha'
  *   post:
  *     summary: Create a project.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Project'
+ *           example:
+ *             tenantId: '507f1f77bcf86cd799439011'
+ *             name: 'Project Alpha'
+ *     responses:
+ *       '200':
+ *         description: Project created.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Project'
+ *             example:
+ *               tenantId: '507f1f77bcf86cd799439011'
+ *               name: 'Project Alpha'
  * /projects/{id}:
  *   put:
  *     summary: Update a project.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Project'
+ *           example:
+ *             tenantId: '507f1f77bcf86cd799439011'
+ *             name: 'Updated Project'
+ *     responses:
+ *       '200':
+ *         description: Project updated.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Project'
+ *             example:
+ *               tenantId: '507f1f77bcf86cd799439011'
+ *               name: 'Updated Project'
  *   delete:
  *     summary: Delete a project.
+ *     responses:
+ *       '200':
+ *         description: Project deleted.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
  */
 export default createTenantRouter('projects', Project, schema);


### PR DESCRIPTION
## Summary
- add reusable Customer and Project schemas to Swagger config
- document customers and projects routes with request/response payloads and examples

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build:server` (fails: Object literal may only specify known properties, and 'status' does not exist in type 'Partial<{ _id: any; }>' )
- `npx tsx -e "import spec from './server/src/config/swagger.ts'; console.log(JSON.stringify(spec, null, 2));"`

------
https://chatgpt.com/codex/tasks/task_e_689f1a4d5df88326a3efb1735a179d33