### PR TITLE
feat: expand core models and swagger docs

### DIFF
--- a/server/src/config/swagger.ts
+++ b/server/src/config/swagger.ts
@@ -24,6 +24,33 @@ const options = {
               description: 'Customer email',
               example: 'john@example.com',
             },
+            firstName: { type: 'string', example: 'John' },
+            lastName: { type: 'string', example: 'Doe' },
+            phone: { type: 'string', example: '+1-555-123-4567' },
+            address: {
+              type: 'object',
+              properties: {
+                street: { type: 'string', example: '123 Main St' },
+                city: { type: 'string', example: 'Springfield' },
+                state: { type: 'string', example: 'IL' },
+                postalCode: { type: 'string', example: '62704' },
+                country: { type: 'string', example: 'USA' },
+              },
+            },
+          },
+          example: {
+            tenantId: '507f1f77bcf86cd799439011',
+            email: 'john@example.com',
+            firstName: 'John',
+            lastName: 'Doe',
+            phone: '+1-555-123-4567',
+            address: {
+              street: '123 Main St',
+              city: 'Springfield',
+              state: 'IL',
+              postalCode: '62704',
+              country: 'USA',
+            },
           },
         },
         Project: {
@@ -35,10 +62,51 @@ const options = {
               description: 'Tenant identifier',
               example: '507f1f77bcf86cd799439011',
             },
+            customerId: {
+              type: 'string',
+              description: 'Customer identifier',
+              example: '507f1f77bcf86cd799439012',
+            },
             name: {
               type: 'string',
               description: 'Project name',
-              example: 'Project Alpha',
+              example: 'Kitchen Remodel',
+            },
+            status: { type: 'string', example: 'planning' },
+            startDate: {
+              type: 'string',
+              format: 'date-time',
+              example: '2024-01-01T00:00:00.000Z',
+            },
+            endDate: {
+              type: 'string',
+              format: 'date-time',
+              example: '2024-02-01T00:00:00.000Z',
+            },
+            address: {
+              type: 'object',
+              properties: {
+                street: { type: 'string', example: '123 Main St' },
+                city: { type: 'string', example: 'Springfield' },
+                state: { type: 'string', example: 'IL' },
+                postalCode: { type: 'string', example: '62704' },
+                country: { type: 'string', example: 'USA' },
+              },
+            },
+          },
+          example: {
+            tenantId: '507f1f77bcf86cd799439011',
+            customerId: '507f1f77bcf86cd799439012',
+            name: 'Kitchen Remodel',
+            status: 'planning',
+            startDate: '2024-01-01T00:00:00.000Z',
+            endDate: '2024-02-01T00:00:00.000Z',
+            address: {
+              street: '123 Main St',
+              city: 'Springfield',
+              state: 'IL',
+              postalCode: '62704',
+              country: 'USA',
             },
           },
         },
@@ -110,11 +178,34 @@ const options = {
               description: 'Price list name',
               example: 'Standard',
             },
+            description: { type: 'string', example: 'Default pricing' },
+            items: {
+              type: 'array',
+              items: {
+                type: 'object',
+                required: ['name', 'price'],
+                properties: {
+                  name: { type: 'string', example: 'Labor' },
+                  unit: { type: 'string', example: 'hr' },
+                  price: { type: 'number', example: 50 },
+                  description: { type: 'string', example: 'Hourly rate' },
+                },
+              },
+            },
+          },
+          example: {
+            tenantId: '507f1f77bcf86cd799439011',
+            name: 'Standard',
+            description: 'Default pricing',
+            items: [
+              { name: 'Labor', unit: 'hr', price: 50 },
+              { name: 'Material', unit: 'item', price: 20, description: 'Wood plank' },
+            ],
           },
         },
         Proposal: {
           type: 'object',
-          required: ['tenantId', 'projectId'],
+          required: ['tenantId', 'projectId', 'customerId'],
           properties: {
             tenantId: {
               type: 'string',
@@ -126,11 +217,47 @@ const options = {
               description: 'Project identifier',
               example: '507f1f77bcf86cd799439012',
             },
+            customerId: {
+              type: 'string',
+              description: 'Customer identifier',
+              example: '507f1f77bcf86cd799439013',
+            },
+            priceListId: {
+              type: 'string',
+              description: 'Associated price list',
+              example: '507f1f77bcf86cd799439014',
+            },
+            notes: { type: 'string', example: 'Initial estimate' },
+            items: {
+              type: 'array',
+              items: {
+                type: 'object',
+                required: ['description', 'unitPrice'],
+                properties: {
+                  description: { type: 'string', example: 'Install cabinets' },
+                  quantity: { type: 'number', example: 1 },
+                  unitPrice: { type: 'number', example: 500 },
+                },
+              },
+            },
+            total: { type: 'number', example: 800 },
+          },
+          example: {
+            tenantId: '507f1f77bcf86cd799439011',
+            projectId: '507f1f77bcf86cd799439012',
+            customerId: '507f1f77bcf86cd799439013',
+            priceListId: '507f1f77bcf86cd799439014',
+            notes: 'Initial estimate',
+            items: [
+              { description: 'Install cabinets', quantity: 1, unitPrice: 500 },
+              { description: 'Paint walls', quantity: 2, unitPrice: 150 },
+            ],
+            total: 800,
           },
         },
         Step: {
           type: 'object',
-          required: ['tenantId', 'projectId'],
+          required: ['tenantId', 'projectId', 'name'],
           properties: {
             tenantId: {
               type: 'string',
@@ -142,6 +269,30 @@ const options = {
               description: 'Project identifier',
               example: '507f1f77bcf86cd799439012',
             },
+            name: { type: 'string', description: 'Step name', example: 'Demolition' },
+            description: { type: 'string', example: 'Remove old fixtures' },
+            order: { type: 'number', example: 1 },
+            status: { type: 'string', example: 'pending' },
+            startDate: {
+              type: 'string',
+              format: 'date-time',
+              example: '2024-01-02T00:00:00.000Z',
+            },
+            endDate: {
+              type: 'string',
+              format: 'date-time',
+              example: '2024-01-05T00:00:00.000Z',
+            },
+          },
+          example: {
+            tenantId: '507f1f77bcf86cd799439011',
+            projectId: '507f1f77bcf86cd799439012',
+            name: 'Demolition',
+            description: 'Remove old fixtures',
+            order: 1,
+            status: 'pending',
+            startDate: '2024-01-02T00:00:00.000Z',
+            endDate: '2024-01-05T00:00:00.000Z',
           },
         },
         Document: {

--- a/server/src/models/Customer.ts
+++ b/server/src/models/Customer.ts
@@ -3,11 +3,31 @@ import { Schema, model, Types } from 'mongoose';
 export interface Customer {
   tenantId: Types.ObjectId;
   email: string;
+  firstName?: string;
+  lastName?: string;
+  phone?: string;
+  address?: {
+    street?: string;
+    city?: string;
+    state?: string;
+    postalCode?: string;
+    country?: string;
+  };
 }
 
 const CustomerSchema = new Schema<Customer>({
   tenantId: { type: Schema.Types.ObjectId, required: true },
   email: { type: String, required: true },
+  firstName: { type: String },
+  lastName: { type: String },
+  phone: { type: String },
+  address: {
+    street: { type: String },
+    city: { type: String },
+    state: { type: String },
+    postalCode: { type: String },
+    country: { type: String },
+  },
 });
 
 CustomerSchema.index({ tenantId: 1, email: 1 });

--- a/server/src/models/PriceList.ts
+++ b/server/src/models/PriceList.ts
@@ -3,11 +3,27 @@ import { Schema, model, Types } from 'mongoose';
 export interface PriceList {
   tenantId: Types.ObjectId;
   name: string;
+  description?: string;
+  items?: {
+    name: string;
+    unit?: string;
+    price: number;
+    description?: string;
+  }[];
 }
 
 const PriceListSchema = new Schema<PriceList>({
   tenantId: { type: Schema.Types.ObjectId, required: true },
   name: { type: String, required: true },
+  description: { type: String },
+  items: [
+    {
+      name: { type: String, required: true },
+      unit: { type: String },
+      price: { type: Number, required: true },
+      description: { type: String },
+    },
+  ],
 });
 
 PriceListSchema.index({ tenantId: 1, name: 1 });

--- a/server/src/models/Project.ts
+++ b/server/src/models/Project.ts
@@ -2,12 +2,34 @@ import { Schema, model, Types } from 'mongoose';
 
 export interface Project {
   tenantId: Types.ObjectId;
+  customerId?: Types.ObjectId;
   name: string;
+  status?: string;
+  startDate?: Date;
+  endDate?: Date;
+  address?: {
+    street?: string;
+    city?: string;
+    state?: string;
+    postalCode?: string;
+    country?: string;
+  };
 }
 
 const ProjectSchema = new Schema<Project>({
   tenantId: { type: Schema.Types.ObjectId, required: true },
+  customerId: { type: Schema.Types.ObjectId },
   name: { type: String, required: true },
+  status: { type: String },
+  startDate: { type: Date },
+  endDate: { type: Date },
+  address: {
+    street: { type: String },
+    city: { type: String },
+    state: { type: String },
+    postalCode: { type: String },
+    country: { type: String },
+  },
 });
 
 ProjectSchema.index({ tenantId: 1, name: 1 });

--- a/server/src/models/Proposal.ts
+++ b/server/src/models/Proposal.ts
@@ -3,11 +3,31 @@ import { Schema, model, Types } from 'mongoose';
 export interface Proposal {
   tenantId: Types.ObjectId;
   projectId: Types.ObjectId;
+  customerId: Types.ObjectId;
+  priceListId?: Types.ObjectId;
+  notes?: string;
+  items?: {
+    description: string;
+    quantity?: number;
+    unitPrice: number;
+  }[];
+  total?: number;
 }
 
 const ProposalSchema = new Schema<Proposal>({
   tenantId: { type: Schema.Types.ObjectId, required: true },
   projectId: { type: Schema.Types.ObjectId, required: true },
+  customerId: { type: Schema.Types.ObjectId, required: true },
+  priceListId: { type: Schema.Types.ObjectId },
+  notes: { type: String },
+  items: [
+    {
+      description: { type: String, required: true },
+      quantity: { type: Number },
+      unitPrice: { type: Number, required: true },
+    },
+  ],
+  total: { type: Number },
 });
 
 ProposalSchema.index({ tenantId: 1, projectId: 1 });

--- a/server/src/models/Step.ts
+++ b/server/src/models/Step.ts
@@ -3,13 +3,25 @@ import { Schema, model, Types } from 'mongoose';
 export interface Step {
   tenantId: Types.ObjectId;
   projectId: Types.ObjectId;
+  name: string;
+  description?: string;
+  order?: number;
+  status?: string;
+  startDate?: Date;
+  endDate?: Date;
 }
 
 const StepSchema = new Schema<Step>({
   tenantId: { type: Schema.Types.ObjectId, required: true },
   projectId: { type: Schema.Types.ObjectId, required: true },
+  name: { type: String, required: true },
+  description: { type: String },
+  order: { type: Number },
+  status: { type: String },
+  startDate: { type: Date },
+  endDate: { type: Date },
 });
 
-StepSchema.index({ tenantId: 1, projectId: 1 });
+StepSchema.index({ tenantId: 1, projectId: 1, order: 1 });
 
 export default model<Step>('Step', StepSchema);


### PR DESCRIPTION
## Summary
- add contact info to Customer
- enrich Project, Step, PriceList and Proposal schemas
- expose new structures in Swagger with examples

## Testing
- `npm run lint`
- `npm run build:server` *(fails: TS2353 Object literal may only specify known properties, and 'status' does not exist in type 'Partial<{ _id: any; }>' )*


------
https://chatgpt.com/codex/tasks/task_e_689f23c242d08326bc947393984127c4