### PR TITLE
docs: document bearer auth in swagger

### DIFF
--- a/server/src/config/swagger.ts
+++ b/server/src/config/swagger.ts
@@ -9,6 +9,13 @@ const options = {
     },
     servers: [{ url: '/api' }],
     components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+        },
+      },
       schemas: {
         Customer: {
           type: 'object',
@@ -388,6 +395,7 @@ const options = {
         },
       },
     },
+    security: [{ bearerAuth: [] }],
   },
   apis: ['server/src/routes/*.ts'],
 };

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -14,6 +14,7 @@ const loginSchema = z.object({
  * /auth/login:
  *   post:
  *     summary: Authenticate user and return a tenant token.
+ *     security: []
  *     requestBody:
  *       required: true
  *       content:


### PR DESCRIPTION
## Summary
- document JWT bearer security scheme in Swagger config
- allow `/auth/login` to be called without authentication

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build:server`


------
https://chatgpt.com/codex/tasks/task_e_689f2ee2a1d883269ea53065334c437b