### PR TITLE
docs: add templates openapi annotations

### DIFF
--- a/server/src/routes/templates.ts
+++ b/server/src/routes/templates.ts
@@ -14,6 +14,108 @@ const schema = z.object({
  * Template routes with validation, pagination and audit logging.
  */
 
+/**
+ * @openapi
+ * /templates:
+ *   get:
+ *     summary: List templates
+ *     tags:
+ *       - Templates
+ *     responses:
+ *       '200':
+ *         description: A paginated list of templates
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 items:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Document'
+ *                 total:
+ *                   type: number
+ *                 page:
+ *                   type: number
+ *   post:
+ *     summary: Create a template
+ *     tags:
+ *       - Templates
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Document'
+ *     responses:
+ *       '201':
+ *         description: Created template
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Document'
+ * /templates/{id}:
+ *   get:
+ *     summary: Get a template by id
+ *     tags:
+ *       - Templates
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       '200':
+ *         description: Template found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Document'
+ *       '404':
+ *         description: Not found
+ *   put:
+ *     summary: Update a template
+ *     tags:
+ *       - Templates
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Document'
+ *     responses:
+ *       '200':
+ *         description: Updated template
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Document'
+ *       '404':
+ *         description: Not found
+ *   delete:
+ *     summary: Delete a template
+ *     tags:
+ *       - Templates
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       '204':
+ *         description: Template deleted
+ *       '404':
+ *         description: Not found
+ */
+
 router.get('/', guard('templates', 'read'), async (req: AuthenticatedRequest, res) => {
   const page = parseInt((req.query.page as string) ?? '1', 10);
   const limit = parseInt((req.query.limit as string) ?? '20', 10);


### PR DESCRIPTION
## Summary
- document /templates endpoints with OpenAPI annotations, tagged Templates

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f3811ffa883269e46f731bfbaa426