### PR TITLE
docs(users): add swagger docs for users routes

### DIFF
--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -11,7 +11,105 @@ const schema = z.object({
 });
 
 /**
- * User routes with validation, pagination and audit logging.
+ * @openapi
+ * /users:
+ *   get:
+ *     summary: List users
+ *     tags:
+ *       - Users
+ *     responses:
+ *       '200':
+ *         description: A paginated list of users
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 items:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/User'
+ *                 total:
+ *                   type: number
+ *                 page:
+ *                   type: number
+ *   post:
+ *     summary: Create a user
+ *     tags:
+ *       - Users
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/User'
+ *     responses:
+ *       '201':
+ *         description: Created user
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/User'
+ * /users/{id}:
+ *   get:
+ *     summary: Get a user by id
+ *     tags:
+ *       - Users
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       '200':
+ *         description: User found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/User'
+ *       '404':
+ *         description: Not found
+ *   put:
+ *     summary: Update a user
+ *     tags:
+ *       - Users
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/User'
+ *     responses:
+ *       '200':
+ *         description: Updated user
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/User'
+ *       '404':
+ *         description: Not found
+ *   delete:
+ *     summary: Delete a user
+ *     tags:
+ *       - Users
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       '204':
+ *         description: User deleted
+ *       '404':
+ *         description: Not found
  */
 
 router.get('/', guard('users', 'read'), async (req: AuthenticatedRequest, res) => {


### PR DESCRIPTION
## Summary
- document `/users` and `/users/{id}` routes with OpenAPI annotations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint -- --file server/src/routes/users.ts` *(fails: import/order and padding-line-between-statements)*

------
https://chatgpt.com/codex/tasks/task_e_689f381344f88326b48479b69a05e606