### PR TITLE
feat: add database seed script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,21 @@ This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-opti
 
 **Note:** Bracketed segments like `[id]` denote parameterized paths.
 
+## Development credentials
+
+Populate the database with initial data by running:
+
+```bash
+pnpm seed
+```
+
+The script inserts a demo tenant and an administrator user:
+
+- **Tenant ID:** `000000000000000000000001`
+- **Admin email:** `admin@example.com`
+
+Use these values when developing locally or seeding additional data.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint:fix": "next lint --fix",
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx}\"",
     "build:icons": "tsx src/assets/iconify-icons/bundle-icons-css.ts",
-    "postinstall": "npm run build:icons"
+    "postinstall": "npm run build:icons",
+    "seed": "tsx server/src/db/seed.ts"
   },
   "dependencies": {
     "@emotion/cache": "11.14.0",

--- a/server/src/db/seed.ts
+++ b/server/src/db/seed.ts
@@ -1,0 +1,26 @@
+import { Types } from 'mongoose';
+import Tenant from '../models/Tenant';
+import User from '../models/User';
+import Membership from '../models/Membership';
+import connectMongo from './mongo';
+
+async function seed() {
+  const mongoose = await connectMongo();
+
+  const tenantId = new Types.ObjectId('000000000000000000000001');
+  const userId = new Types.ObjectId('000000000000000000000002');
+
+  const tenant = await Tenant.create({ _id: tenantId, tenantId, name: 'Demo Tenant' });
+  const user = await User.create({ _id: userId, tenantId, email: 'admin@example.com' });
+  await Membership.create({ tenantId, userId, role: 'admin' });
+
+  console.log('Seeded tenant ID:', tenant.tenantId.toString());
+  console.log('Seeded admin user:', user.email);
+
+  await mongoose.disconnect();
+}
+
+seed().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- seed database with demo tenant, admin user and membership
- document seed credentials
- expose seed script via `pnpm seed`

## Testing
- `pnpm lint`
- `pnpm seed` *(fails: MongooseServerSelectionError: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68a02e6f28c883268dbb500f6a4449b6