### PR TITLE
Use template login page with new auth logic

### DIFF
--- a/src/app/(blank-layout-pages)/login/page.tsx
+++ b/src/app/(blank-layout-pages)/login/page.tsx
@@ -1,35 +1,10 @@
-'use client';
+import LoginView from '@views/Login'
+import { getServerMode } from '@core/utils/serverHelpers'
 
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
-import { LoginSchema } from '@/server/validation/auth';
-import { useAuth } from '@/@core/contexts/authContext';
-
-type FormValues = z.infer<typeof LoginSchema>;
-
-export default function LoginPage() {
-  const { login } = useAuth();
-  const { register, handleSubmit, formState: { errors }, setError } = useForm<FormValues>({ resolver: zodResolver(LoginSchema) });
-
-  const onSubmit = async (data: FormValues) => {
-    try {
-      await login(data);
-    } catch (e) {
-      setError('root', { message: 'Invalid credentials' });
-    }
-  };
-
-  return (
-    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
-      <input {...register('tenantCode')} placeholder="Tenant Code" />
-      {errors.tenantCode && <span>{errors.tenantCode.message}</span>}
-      <input {...register('email')} placeholder="Email" />
-      {errors.email && <span>{errors.email.message}</span>}
-      <input type="password" {...register('password')} placeholder="Password" />
-      {errors.password && <span>{errors.password.message}</span>}
-      {errors.root && <span>{errors.root.message}</span>}
-      <button type="submit">Login</button>
-    </form>
-  );
+const LoginPage = async () => {
+  const mode = await getServerMode()
+  
+  return <LoginView mode={mode} />
 }
+
+export default LoginPage


### PR DESCRIPTION
## Summary
- Render existing template login view in route
- Refactor login view to use new auth context and validation

## Testing
- `npm test` *(fails: Invalid environment variables MONGODB_URI)*
- `npm run lint` *(fails: multiple ESLint errors across project)*

------
https://chatgpt.com/codex/tasks/task_e_68a44ef350f0832680ce7c847a4c5161