### PR TITLE
fix: enable login page API call

### DIFF
--- a/src/app/(blank-layout-pages)/layout.tsx
+++ b/src/app/(blank-layout-pages)/layout.tsx
@@ -4,6 +4,7 @@ import type { ChildrenType } from '@core/types'
 // Component Imports
 import Providers from '@components/Providers'
 import BlankLayout from '@layouts/BlankLayout'
+import { AuthProvider } from '@core/contexts/authContext'
 
 // Util Imports
 import { getSystemMode } from '@core/utils/serverHelpers'
@@ -18,9 +19,11 @@ const Layout = async (props: Props) => {
   const systemMode = await getSystemMode()
 
   return (
-    <Providers direction={direction}>
-      <BlankLayout systemMode={systemMode}>{children}</BlankLayout>
-    </Providers>
+    <AuthProvider>
+      <Providers direction={direction}>
+        <BlankLayout systemMode={systemMode}>{children}</BlankLayout>
+      </Providers>
+    </AuthProvider>
   )
 }
 


### PR DESCRIPTION
## Summary
- wrap blank layout pages with AuthProvider so login calls API

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a46f86a878832682d3c80681247cb3