### PR TITLE
feat: add basic CRM API routes

### DIFF
--- a/src/app/api/admin/standard-steps/route.ts
+++ b/src/app/api/admin/standard-steps/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth } from '@/server/middleware/auth';
+import { connectDb } from '@/server/db/connection';
+import StandardStep from '@/server/db/models/StandardStep';
+
+export async function GET() {
+  try {
+    const me = requireAuth(['admin'])();
+    await connectDb();
+    const docs = await StandardStep.find({ tenantId: me.tenantId }).sort({ stepNo: 1 }).lean();
+    return NextResponse.json(docs);
+  } catch (e: any) {
+    if (e.message === 'UNAUTHORIZED') return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 });
+    if (e.message === 'FORBIDDEN') return NextResponse.json({ error: 'FORBIDDEN' }, { status: 403 });
+    return NextResponse.json({ error: 'ERROR' }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const me = requireAuth(['admin'])();
+    await connectDb();
+    const steps = await req.json();
+    if (!Array.isArray(steps)) return NextResponse.json({ error: 'INVALID' }, { status: 400 });
+    for (const s of steps) {
+      await StandardStep.updateOne(
+        { tenantId: me.tenantId, stepNo: s.stepNo },
+        { $set: { ...s, tenantId: me.tenantId } },
+        { upsert: true }
+      );
+    }
+    return NextResponse.json({ ok: true });
+  } catch (e: any) {
+    if (e.message === 'UNAUTHORIZED') return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 });
+    if (e.message === 'FORBIDDEN') return NextResponse.json({ error: 'FORBIDDEN' }, { status: 403 });
+    return NextResponse.json({ error: 'ERROR' }, { status: 500 });
+  }
+}

--- a/src/app/api/crm/customers/[id]/route.ts
+++ b/src/app/api/crm/customers/[id]/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth } from '@/server/middleware/auth';
+import { connectDb } from '@/server/db/connection';
+import Customer from '@/server/db/models/Customer';
+import { CustomerSchema } from '@/server/validation/crm';
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const me = requireAuth()();
+    await connectDb();
+    const doc = await Customer.findOne({ _id: params.id, tenantId: me.tenantId }).lean();
+    if (!doc) return NextResponse.json({ error: 'NOT_FOUND' }, { status: 404 });
+    return NextResponse.json(doc);
+  } catch (e: any) {
+    if (e.message === 'UNAUTHORIZED') return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 });
+    if (e.message === 'FORBIDDEN') return NextResponse.json({ error: 'FORBIDDEN' }, { status: 403 });
+    return NextResponse.json({ error: 'ERROR' }, { status: 500 });
+  }
+}
+
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const me = requireAuth(['admin', 'rep'])();
+    await connectDb();
+    const body = await req.json();
+    const data = CustomerSchema.partial().parse(body);
+    await Customer.updateOne({ _id: params.id, tenantId: me.tenantId }, { $set: data });
+    return NextResponse.json({ ok: true });
+  } catch (e: any) {
+    if (e.message === 'UNAUTHORIZED') return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 });
+    if (e.message === 'FORBIDDEN') return NextResponse.json({ error: 'FORBIDDEN' }, { status: 403 });
+    if (e.name === 'ZodError') return NextResponse.json({ error: 'VALIDATION', details: e.errors }, { status: 400 });
+    return NextResponse.json({ error: 'ERROR' }, { status: 500 });
+  }
+}

--- a/src/app/api/crm/customers/route.ts
+++ b/src/app/api/crm/customers/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth } from '@/server/middleware/auth';
+import { connectDb } from '@/server/db/connection';
+import Customer from '@/server/db/models/Customer';
+import Tenant from '@/server/db/models/Tenant';
+import { CustomerSchema } from '@/server/validation/crm';
+import { nanoid } from 'nanoid';
+
+export async function GET(req: NextRequest) {
+  try {
+    const me = requireAuth()();
+    await connectDb();
+
+    const q = req.nextUrl.searchParams.get('q') || '';
+    const skip = Number(req.nextUrl.searchParams.get('skip') || '0');
+    const limit = Number(req.nextUrl.searchParams.get('limit') || '50');
+
+    const filter: any = { tenantId: me.tenantId };
+    if (q) {
+      const regex = new RegExp(q, 'i');
+      filter.$or = [
+        { customerName: regex },
+        { 'contact.email1': regex },
+        { 'contact.mobile1': regex }
+      ];
+    }
+
+    const docs = await Customer.find(filter).skip(skip).limit(limit).lean();
+    return NextResponse.json(docs);
+  } catch (e: any) {
+    if (e.message === 'UNAUTHORIZED') return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 });
+    if (e.message === 'FORBIDDEN') return NextResponse.json({ error: 'FORBIDDEN' }, { status: 403 });
+    return NextResponse.json({ error: 'ERROR' }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const me = requireAuth(['admin', 'rep'])();
+    await connectDb();
+    const body = await req.json();
+    const data = CustomerSchema.parse(body);
+
+    if (data.contact?.email1) {
+      const existing = await Customer.findOne({ tenantId: me.tenantId, customerName: data.customerName, 'contact.email1': data.contact.email1 }).lean();
+      if (existing) {
+        return NextResponse.json({ suggestion: existing._id }, { status: 409 });
+      }
+    }
+
+    const tenant = await Tenant.findById(me.tenantId).lean();
+    const now = new Date();
+    const yy = String(now.getFullYear()).slice(-2);
+    const customerNo = `${tenant?.code || 'TENANT'}-${yy}-${nanoid(5)}`;
+
+    const doc = await Customer.create({ ...data, tenantId: me.tenantId, customerNo });
+    return NextResponse.json({ id: doc._id.toString(), customerNo }, { status: 201 });
+  } catch (e: any) {
+    if (e.message === 'UNAUTHORIZED') return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 });
+    if (e.message === 'FORBIDDEN') return NextResponse.json({ error: 'FORBIDDEN' }, { status: 403 });
+    if (e.name === 'ZodError') return NextResponse.json({ error: 'VALIDATION', details: e.errors }, { status: 400 });
+    return NextResponse.json({ error: 'ERROR' }, { status: 500 });
+  }
+}

--- a/src/app/api/crm/projects/[id]/route.ts
+++ b/src/app/api/crm/projects/[id]/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth } from '@/server/middleware/auth';
+import { connectDb } from '@/server/db/connection';
+import Project from '@/server/db/models/Project';
+import { ProjectSchema } from '@/server/validation/crm';
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const me = requireAuth()();
+    await connectDb();
+    const filter: any = { _id: params.id, tenantId: me.tenantId };
+    if (me.role === 'rep') filter.repId = me.sub;
+    const doc = await Project.findOne(filter).lean();
+    if (!doc) return NextResponse.json({ error: 'NOT_FOUND' }, { status: 404 });
+    return NextResponse.json(doc);
+  } catch (e: any) {
+    if (e.message === 'UNAUTHORIZED') return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 });
+    if (e.message === 'FORBIDDEN') return NextResponse.json({ error: 'FORBIDDEN' }, { status: 403 });
+    return NextResponse.json({ error: 'ERROR' }, { status: 500 });
+  }
+}
+
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const me = requireAuth(['admin', 'rep'])();
+    await connectDb();
+    const body = await req.json();
+    const data = ProjectSchema.partial().parse(body);
+    const project = await Project.findOne({ _id: params.id, tenantId: me.tenantId });
+    if (!project) return NextResponse.json({ error: 'NOT_FOUND' }, { status: 404 });
+    if (me.role === 'rep' && project.repId.toString() !== me.sub) {
+      return NextResponse.json({ error: 'FORBIDDEN' }, { status: 403 });
+    }
+    Object.assign(project, data);
+    await project.save();
+    return NextResponse.json({ ok: true });
+  } catch (e: any) {
+    if (e.message === 'UNAUTHORIZED') return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 });
+    if (e.message === 'FORBIDDEN') return NextResponse.json({ error: 'FORBIDDEN' }, { status: 403 });
+    if (e.name === 'ZodError') return NextResponse.json({ error: 'VALIDATION', details: e.errors }, { status: 400 });
+    return NextResponse.json({ error: 'ERROR' }, { status: 500 });
+  }
+}

--- a/src/app/api/crm/projects/[id]/steps/[stepNo]/route.ts
+++ b/src/app/api/crm/projects/[id]/steps/[stepNo]/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth } from '@/server/middleware/auth';
+import { connectDb } from '@/server/db/connection';
+import JobStep from '@/server/db/models/JobStep';
+
+export async function PATCH(req: NextRequest, { params }: { params: { id: string; stepNo: string } }) {
+  try {
+    const me = requireAuth(['admin', 'rep'])();
+    await connectDb();
+    const body = await req.json();
+    await JobStep.updateOne(
+      { tenantId: me.tenantId, projectId: params.id, stepNo: Number(params.stepNo) },
+      { $set: body }
+    );
+    return NextResponse.json({ ok: true });
+  } catch (e: any) {
+    if (e.message === 'UNAUTHORIZED') return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 });
+    if (e.message === 'FORBIDDEN') return NextResponse.json({ error: 'FORBIDDEN' }, { status: 403 });
+    return NextResponse.json({ error: 'ERROR' }, { status: 500 });
+  }
+}

--- a/src/app/api/crm/projects/[id]/steps/route.ts
+++ b/src/app/api/crm/projects/[id]/steps/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth } from '@/server/middleware/auth';
+import { connectDb } from '@/server/db/connection';
+import JobStep from '@/server/db/models/JobStep';
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const me = requireAuth()();
+    await connectDb();
+    const docs = await JobStep.find({ tenantId: me.tenantId, projectId: params.id }).sort({ stepNo: 1 }).lean();
+    return NextResponse.json(docs);
+  } catch (e: any) {
+    if (e.message === 'UNAUTHORIZED') return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 });
+    if (e.message === 'FORBIDDEN') return NextResponse.json({ error: 'FORBIDDEN' }, { status: 403 });
+    return NextResponse.json({ error: 'ERROR' }, { status: 500 });
+  }
+}

--- a/src/app/api/crm/projects/route.ts
+++ b/src/app/api/crm/projects/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth } from '@/server/middleware/auth';
+import { connectDb } from '@/server/db/connection';
+import Project from '@/server/db/models/Project';
+import Customer from '@/server/db/models/Customer';
+import JobStep from '@/server/db/models/JobStep';
+import Tenant from '@/server/db/models/Tenant';
+import { ProjectSchema } from '@/server/validation/crm';
+import { ensureCustomer } from '@/server/services/customers';
+import { seedJobStepsFromStandard } from '@/server/services/steps';
+import { nextJobNo } from '@/server/services/sequence';
+
+export async function GET(req: NextRequest) {
+  try {
+    const me = requireAuth()();
+    await connectDb();
+    const params = req.nextUrl.searchParams;
+    const q = params.get('q') || '';
+    const repId = params.get('repId');
+    const status = params.get('status');
+    const skip = Number(params.get('skip') || '0');
+    const limit = Number(params.get('limit') || '50');
+
+    const filter: any = { tenantId: me.tenantId };
+    if (status) filter.status = status;
+    if (me.role === 'rep') filter.repId = me.sub;
+    if (repId) filter.repId = repId;
+    if (q) {
+      const regex = new RegExp(q, 'i');
+      filter.$or = [ { projectName: regex }, { jobNo: regex } ];
+    }
+
+    const docs = await Project.find(filter).skip(skip).limit(limit).lean();
+    return NextResponse.json(docs);
+  } catch (e: any) {
+    if (e.message === 'UNAUTHORIZED') return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 });
+    if (e.message === 'FORBIDDEN') return NextResponse.json({ error: 'FORBIDDEN' }, { status: 403 });
+    return NextResponse.json({ error: 'ERROR' }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const me = requireAuth(['admin', 'rep'])();
+    await connectDb();
+    const body = await req.json();
+    const data = ProjectSchema.parse(body);
+
+    if (!data.customerId && !data.newCustomer) {
+      return NextResponse.json({ error: 'CUSTOMER_REQUIRED' }, { status: 400 });
+    }
+
+    const customerId = await ensureCustomer({ tenantId: me.tenantId, customerId: data.customerId, newCustomer: data.newCustomer });
+    const customer = await Customer.findOne({ _id: customerId, tenantId: me.tenantId }).lean();
+    const contact = customer?.contact || {};
+    const reachable = (contact.email1 && contact.email1Notify !== false) || (contact.mobile1 && contact.mobile1Notify !== false);
+    if (!reachable) {
+      return NextResponse.json({ error: 'CONTACT_REQUIRED' }, { status: 400 });
+    }
+    if (!data.council?.name) {
+      return NextResponse.json({ error: 'COUNCIL_REQUIRED' }, { status: 400 });
+    }
+
+    const tenant = await Tenant.findById(me.tenantId).lean();
+    const jobNo = await nextJobNo(tenant?.code || 'TENANT');
+
+    const project = await Project.create({
+      tenantId: me.tenantId,
+      customerId,
+      projectName: data.projectName,
+      jobType: data.jobType,
+      spaType: data.spaType,
+      veType: data.veType,
+      siteType: data.siteType,
+      repId: data.repId,
+      clientRequestDate: data.clientRequestDate,
+      siteAddress: data.siteAddress,
+      sitePostcode: data.sitePostcode,
+      council: data.council,
+      jobNotes: data.jobNotes,
+      status: 'lead',
+      issueNo: 1,
+      jobNo
+    });
+
+    if (data.steps && data.steps.length) {
+      for (const s of data.steps) {
+        await JobStep.create({ tenantId: me.tenantId, projectId: project._id, ...s });
+      }
+    } else {
+      await seedJobStepsFromStandard({ tenantId: me.tenantId, projectId: project._id.toString() });
+    }
+
+    return NextResponse.json({ id: project._id.toString(), jobNo }, { status: 201 });
+  } catch (e: any) {
+    if (e.message === 'UNAUTHORIZED') return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 });
+    if (e.message === 'FORBIDDEN') return NextResponse.json({ error: 'FORBIDDEN' }, { status: 403 });
+    if (e.name === 'ZodError') return NextResponse.json({ error: 'VALIDATION', details: e.errors }, { status: 400 });
+    return NextResponse.json({ error: 'ERROR' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add customer CRUD handlers with tenant-scoped queries and customer number generation
- support project lead creation with auto job numbers and optional step seeding
- expose job step and standard step routes for managing project workflow

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68a47c95a83c8326a8504ca6c11da825