### PR TITLE
feat: add CRM navigation

### DIFF
--- a/src/components/GenerateMenu.tsx
+++ b/src/components/GenerateMenu.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 // React Imports
 import type { ReactNode } from 'react'
 
@@ -20,99 +22,114 @@ import { SubMenu as HorizontalSubMenu, MenuItem as HorizontalMenuItem } from '@m
 import { SubMenu as VerticalSubMenu, MenuItem as VerticalMenuItem, MenuSection } from '@menu/vertical-menu'
 import CustomChip from '@core/components/mui/Chip'
 
+// Context & Util Imports
+import { useAuth } from '@/@core/contexts/authContext'
+import { hasRole } from '@/utils/rbac'
+
 // Generate a menu from the menu data array
 export const GenerateVerticalMenu = ({ menuData }: { menuData: VerticalMenuDataType[] }) => {
   // Hooks
+  const { user } = useAuth()
 
-  const renderMenuItems = (data: VerticalMenuDataType[]) => {
-    // Use the map method to iterate through the array of menu data
-    return data.map((item: VerticalMenuDataType, index) => {
-      const menuSectionItem = item as VerticalSectionDataType
-      const subMenuItem = item as VerticalSubMenuDataType
-      const menuItem = item as VerticalMenuItemDataType
+  const renderMenuItems = (data: VerticalMenuDataType[]): JSX.Element[] => {
+    // Filter menu based on roles and iterate
+    return data
+      .filter(item => {
+        const roles = (item as any).roles
 
-      // Check if the current item is a section
-      if (menuSectionItem.isSection) {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { children, isSection, ...rest } = menuSectionItem
+        return roles ? (user ? hasRole([user.role], roles) : false) : true
+      })
+      .map((item: VerticalMenuDataType, index) => {
+        const menuSectionItem = item as VerticalSectionDataType
+        const subMenuItem = item as VerticalSubMenuDataType
+        const menuItem = item as VerticalMenuItemDataType
 
-        // If it is, return a MenuSection component and call generateMenu with the current menuSectionItem's children
-        return (
-          <MenuSection key={index} {...rest}>
-            {children && renderMenuItems(children)}
-          </MenuSection>
-        )
-      }
+        // Check if the current item is a section
+        if (menuSectionItem.isSection) {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { children, isSection, ...rest } = menuSectionItem
 
-      // Check if the current item is a sub menu
-      if (subMenuItem.children) {
-        const { children, icon, prefix, suffix, ...rest } = subMenuItem
+          // If it is, return a MenuSection component and call generateMenu with the current menuSectionItem's children
+          return (
+            <MenuSection key={index} {...rest}>
+              {children && renderMenuItems(children)}
+            </MenuSection>
+          )
+        }
+
+        // Check if the current item is a sub menu
+        if (subMenuItem.children) {
+          const { children, icon, prefix, suffix, ...rest } = subMenuItem
+
+          const childItems = children ? renderMenuItems(children) : []
+
+          if (childItems.length === 0) return null
+
+          const Icon = icon ? <i className={icon} /> : null
+
+          const subMenuPrefix: ReactNode =
+            prefix && (prefix as ChipProps).label ? (
+              <CustomChip size='small' round='true' {...(prefix as ChipProps)} />
+            ) : (
+              (prefix as ReactNode)
+            )
+
+          const subMenuSuffix: ReactNode =
+            suffix && (suffix as ChipProps).label ? (
+              <CustomChip size='small' round='true' {...(suffix as ChipProps)} />
+            ) : (
+              (suffix as ReactNode)
+            )
+
+          // If it is, return a SubMenu component and call generateMenu with the current subMenuItem's children
+          return (
+            <VerticalSubMenu
+              key={index}
+              prefix={subMenuPrefix}
+              suffix={subMenuSuffix}
+              {...rest}
+              {...(Icon && { icon: Icon })}
+            >
+              {childItems}
+            </VerticalSubMenu>
+          )
+        }
+
+        // If the current item is neither a section nor a sub menu, return a MenuItem component
+        const { label, icon, prefix, suffix, ...rest } = menuItem
+
+        // Localize the href
+        const href = rest.href
 
         const Icon = icon ? <i className={icon} /> : null
 
-        const subMenuPrefix: ReactNode =
+        const menuItemPrefix: ReactNode =
           prefix && (prefix as ChipProps).label ? (
             <CustomChip size='small' round='true' {...(prefix as ChipProps)} />
           ) : (
             (prefix as ReactNode)
           )
 
-        const subMenuSuffix: ReactNode =
+        const menuItemSuffix: ReactNode =
           suffix && (suffix as ChipProps).label ? (
             <CustomChip size='small' round='true' {...(suffix as ChipProps)} />
           ) : (
             (suffix as ReactNode)
           )
 
-        // If it is, return a SubMenu component and call generateMenu with the current subMenuItem's children
         return (
-          <VerticalSubMenu
+          <VerticalMenuItem
             key={index}
-            prefix={subMenuPrefix}
-            suffix={subMenuSuffix}
+            prefix={menuItemPrefix}
+            suffix={menuItemSuffix}
             {...rest}
+            href={href}
             {...(Icon && { icon: Icon })}
           >
-            {children && renderMenuItems(children)}
-          </VerticalSubMenu>
+            {label}
+          </VerticalMenuItem>
         )
-      }
-
-      // If the current item is neither a section nor a sub menu, return a MenuItem component
-      const { label, icon, prefix, suffix, ...rest } = menuItem
-
-      // Localize the href
-      const href = rest.href
-
-      const Icon = icon ? <i className={icon} /> : null
-
-      const menuItemPrefix: ReactNode =
-        prefix && (prefix as ChipProps).label ? (
-          <CustomChip size='small' round='true' {...(prefix as ChipProps)} />
-        ) : (
-          (prefix as ReactNode)
-        )
-
-      const menuItemSuffix: ReactNode =
-        suffix && (suffix as ChipProps).label ? (
-          <CustomChip size='small' round='true' {...(suffix as ChipProps)} />
-        ) : (
-          (suffix as ReactNode)
-        )
-
-      return (
-        <VerticalMenuItem
-          key={index}
-          prefix={menuItemPrefix}
-          suffix={menuItemSuffix}
-          {...rest}
-          href={href}
-          {...(Icon && { icon: Icon })}
-        >
-          {label}
-        </VerticalMenuItem>
-      )
-    })
+      })
   }
 
   return <>{renderMenuItems(menuData)}</>
@@ -121,82 +138,93 @@ export const GenerateVerticalMenu = ({ menuData }: { menuData: VerticalMenuDataT
 // Generate a menu from the menu data array
 export const GenerateHorizontalMenu = ({ menuData }: { menuData: HorizontalMenuDataType[] }) => {
   // Hooks
+  const { user } = useAuth()
 
-  const renderMenuItems = (data: HorizontalMenuDataType[]) => {
-    // Use the map method to iterate through the array of menu data
-    return data.map((item: HorizontalMenuDataType, index) => {
-      const subMenuItem = item as HorizontalSubMenuDataType
-      const menuItem = item as HorizontalMenuItemDataType
+  const renderMenuItems = (data: HorizontalMenuDataType[]): JSX.Element[] => {
+    // Filter menu based on roles and iterate
+    return data
+      .filter(item => {
+        const roles = (item as any).roles
 
-      // Check if the current item is a sub menu
-      if (subMenuItem.children) {
-        const { children, icon, prefix, suffix, ...rest } = subMenuItem
+        return roles ? (user ? hasRole([user.role], roles) : false) : true
+      })
+      .map((item: HorizontalMenuDataType, index) => {
+        const subMenuItem = item as HorizontalSubMenuDataType
+        const menuItem = item as HorizontalMenuItemDataType
+
+        // Check if the current item is a sub menu
+        if (subMenuItem.children) {
+          const { children, icon, prefix, suffix, ...rest } = subMenuItem
+
+          const childItems = children ? renderMenuItems(children) : []
+
+          if (childItems.length === 0) return null
+
+          const Icon = icon ? <i className={icon} /> : null
+
+          const subMenuPrefix: ReactNode =
+            prefix && (prefix as ChipProps).label ? (
+              <CustomChip size='small' round='true' {...(prefix as ChipProps)} />
+            ) : (
+              (prefix as ReactNode)
+            )
+
+          const subMenuSuffix: ReactNode =
+            suffix && (suffix as ChipProps).label ? (
+              <CustomChip size='small' round='true' {...(suffix as ChipProps)} />
+            ) : (
+              (suffix as ReactNode)
+            )
+
+          // If it is, return a SubMenu component and call generateMenu with the current subMenuItem's children
+          return (
+            <HorizontalSubMenu
+              key={index}
+              prefix={subMenuPrefix}
+              suffix={subMenuSuffix}
+              {...rest}
+              {...(Icon && { icon: Icon })}
+            >
+              {childItems}
+            </HorizontalSubMenu>
+          )
+        }
+
+        // If the current item is not a sub menu, return a MenuItem component
+        const { label, icon, prefix, suffix, ...rest } = menuItem
+
+        // Localize the href
+        const href = rest.href
 
         const Icon = icon ? <i className={icon} /> : null
 
-        const subMenuPrefix: ReactNode =
+        const menuItemPrefix: ReactNode =
           prefix && (prefix as ChipProps).label ? (
             <CustomChip size='small' round='true' {...(prefix as ChipProps)} />
           ) : (
             (prefix as ReactNode)
           )
 
-        const subMenuSuffix: ReactNode =
+        const menuItemSuffix: ReactNode =
           suffix && (suffix as ChipProps).label ? (
             <CustomChip size='small' round='true' {...(suffix as ChipProps)} />
           ) : (
             (suffix as ReactNode)
           )
 
-        // If it is, return a SubMenu component and call generateMenu with the current subMenuItem's children
         return (
-          <HorizontalSubMenu
+          <HorizontalMenuItem
             key={index}
-            prefix={subMenuPrefix}
-            suffix={subMenuSuffix}
+            prefix={menuItemPrefix}
+            suffix={menuItemSuffix}
             {...rest}
+            href={href}
             {...(Icon && { icon: Icon })}
           >
-            {children && renderMenuItems(children)}
-          </HorizontalSubMenu>
+            {label}
+          </HorizontalMenuItem>
         )
-      }
-
-      // If the current item is not a sub menu, return a MenuItem component
-      const { label, icon, prefix, suffix, ...rest } = menuItem
-
-      // Localize the href
-      const href = rest.href
-
-      const Icon = icon ? <i className={icon} /> : null
-
-      const menuItemPrefix: ReactNode =
-        prefix && (prefix as ChipProps).label ? (
-          <CustomChip size='small' round='true' {...(prefix as ChipProps)} />
-        ) : (
-          (prefix as ReactNode)
-        )
-
-      const menuItemSuffix: ReactNode =
-        suffix && (suffix as ChipProps).label ? (
-          <CustomChip size='small' round='true' {...(suffix as ChipProps)} />
-        ) : (
-          (suffix as ReactNode)
-        )
-
-      return (
-        <HorizontalMenuItem
-          key={index}
-          prefix={menuItemPrefix}
-          suffix={menuItemSuffix}
-          {...rest}
-          href={href}
-          {...(Icon && { icon: Icon })}
-        >
-          {label}
-        </HorizontalMenuItem>
-      )
-    })
+      })
   }
 
   return <>{renderMenuItems(menuData)}</>

--- a/src/data/navigation/horizontalMenuData.tsx
+++ b/src/data/navigation/horizontalMenuData.tsx
@@ -28,6 +28,25 @@ const horizontalMenuData = (): HorizontalMenuDataType[] => [
     icon: 'tabler-currency-dollar'
   },
   {
+    label: 'CRM',
+    icon: 'tabler-users',
+    roles: ['admin', 'rep', 'user'],
+    children: [
+      {
+        label: 'Leads',
+        href: '/crm/leads',
+        icon: 'tabler-user-plus',
+        roles: ['admin', 'rep']
+      },
+      {
+        label: 'Customers',
+        href: '/crm/customers',
+        icon: 'tabler-user-check',
+        roles: ['admin', 'rep', 'user']
+      }
+    ]
+  },
+  {
     label: 'Admin',
     icon: 'tabler-settings',
     children: [

--- a/src/data/navigation/verticalMenuData.tsx
+++ b/src/data/navigation/verticalMenuData.tsx
@@ -28,6 +28,25 @@ const verticalMenuData = (): VerticalMenuDataType[] => [
     icon: 'tabler-currency-dollar'
   },
   {
+    label: 'CRM',
+    icon: 'tabler-users',
+    roles: ['admin', 'rep', 'user'],
+    children: [
+      {
+        label: 'Leads',
+        href: '/crm/leads',
+        icon: 'tabler-user-plus',
+        roles: ['admin', 'rep']
+      },
+      {
+        label: 'Customers',
+        href: '/crm/customers',
+        icon: 'tabler-user-check',
+        roles: ['admin', 'rep', 'user']
+      }
+    ]
+  },
+  {
     label: 'Admin',
     icon: 'tabler-settings',
     children: [

--- a/src/types/menuTypes.ts
+++ b/src/types/menuTypes.ts
@@ -4,6 +4,9 @@ import type { ReactNode } from 'react'
 // MUI Imports
 import type { ChipProps } from '@mui/material/Chip'
 
+// Role Imports
+import type { Role } from '@/server/security/jwt'
+
 // Type Imports
 import type {
   SubMenuProps as VerticalSubMenuProps,
@@ -27,12 +30,14 @@ export type VerticalMenuItemDataType = Omit<
     icon?: string
     prefix?: ReactNode | ChipProps
     suffix?: ReactNode | ChipProps
+    roles?: Role[]
   }
 export type VerticalSubMenuDataType = Omit<VerticalSubMenuProps, 'children' | 'icon' | 'prefix' | 'suffix'> & {
   children: VerticalMenuDataType[]
   icon?: string
   prefix?: ReactNode | ChipProps
   suffix?: ReactNode | ChipProps
+  roles?: Role[]
 }
 export type VerticalSectionDataType = Omit<VerticalMenuSectionProps, 'children'> & {
   isSection: boolean
@@ -51,11 +56,13 @@ export type HorizontalMenuItemDataType = Omit<
     icon?: string
     prefix?: ReactNode | ChipProps
     suffix?: ReactNode | ChipProps
+    roles?: Role[]
   }
 export type HorizontalSubMenuDataType = Omit<HorizontalSubMenuProps, 'children' | 'icon' | 'prefix' | 'suffix'> & {
   children: HorizontalMenuDataType[]
   icon?: string
   prefix?: ReactNode | ChipProps
   suffix?: ReactNode | ChipProps
+  roles?: Role[]
 }
 export type HorizontalMenuDataType = HorizontalMenuItemDataType | HorizontalSubMenuDataType


### PR DESCRIPTION
## Summary
- add CRM menu section with leads and customers links
- include role-based visibility metadata
- filter navigation items by user role

## Testing
- `npm run lint` (fails: numerous pre-existing lint errors)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a47fa06aa0832690b731060ee1e43b