### PR TITLE
Redirect login to home and update navigation

### DIFF
--- a/src/@core/contexts/authContext.tsx
+++ b/src/@core/contexts/authContext.tsx
@@ -28,16 +28,18 @@ export const AuthProvider = ({ children, initialUser }: { children: ReactNode; i
     // Store token for subsequent authenticated requests
     if (typeof window !== 'undefined') {
       localStorage.setItem('token', res.token)
+      document.cookie = `access_token=${res.token}; path=/`
     }
 
     setUser(res.user)
-    router.push('/dashboard')
+    router.push('/home')
   }
 
   const logout = () => {
     // Remove stored token on logout
     if (typeof window !== 'undefined') {
       localStorage.removeItem('token')
+      document.cookie = 'access_token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
     }
 
     setUser(null)

--- a/src/components/layout/horizontal/HorizontalMenu.tsx
+++ b/src/components/layout/horizontal/HorizontalMenu.tsx
@@ -78,7 +78,7 @@ const HorizontalMenu = () => {
           menuSectionStyles: verticalMenuSectionStyles(verticalNavOptions, theme)
         }}
       >
-        <MenuItem href='/' icon={<i className='tabler-smart-home' />}>
+        <MenuItem href='/home' icon={<i className='tabler-smart-home' />}>
           Home
         </MenuItem>
         <MenuItem href='/about' icon={<i className='tabler-info-circle' />}>

--- a/src/components/layout/horizontal/VerticalNavContent.tsx
+++ b/src/components/layout/horizontal/VerticalNavContent.tsx
@@ -70,7 +70,7 @@ const VerticalNavContent = ({ children }: ChildrenType) => {
   return (
     <>
       <NavHeader>
-        <Link href='/'>
+        <Link href='/home'>
           <Logo />
         </Link>
         <NavCollapseIcons

--- a/src/components/layout/vertical/Navigation.tsx
+++ b/src/components/layout/vertical/Navigation.tsx
@@ -108,7 +108,7 @@ const Navigation = (props: Props) => {
     >
       {/* Nav Header including Logo & nav toggle icons  */}
       <NavHeader>
-        <Link href='/'>
+        <Link href='/home'>
           <Logo />
         </Link>
         {!(isCollapsed && !isHovered) && (

--- a/src/data/navigation/horizontalMenuData.tsx
+++ b/src/data/navigation/horizontalMenuData.tsx
@@ -2,11 +2,11 @@
 import type { HorizontalMenuDataType } from '@/types/menuTypes'
 
 const horizontalMenuData = (): HorizontalMenuDataType[] => [
-  // {
-  //   label: 'Dashboard',
-  //   href: '/dashboard',
-  //   icon: 'tabler-layout-dashboard'
-  // },
+  {
+    label: 'Home',
+    href: '/home',
+    icon: 'tabler-smart-home'
+  },
   {
     label: 'Projects',
     href: '/projects',

--- a/src/data/navigation/verticalMenuData.tsx
+++ b/src/data/navigation/verticalMenuData.tsx
@@ -2,11 +2,11 @@
 import type { VerticalMenuDataType } from '@/types/menuTypes'
 
 const verticalMenuData = (): VerticalMenuDataType[] => [
-  // {
-  //   label: 'Dashboard',
-  //   href: '/dashboard',
-  //   icon: 'tabler-layout-dashboard'
-  // },
+  {
+    label: 'Home',
+    href: '/home',
+    icon: 'tabler-smart-home'
+  },
   {
     label: 'Projects',
     href: '/projects',

--- a/src/views/NotFound.tsx
+++ b/src/views/NotFound.tsx
@@ -48,7 +48,7 @@ const NotFound = ({ mode }: { mode: SystemMode }) => {
           <Typography variant='h4'>Page Not Found ⚠️</Typography>
           <Typography>we couldn&#39;t find the page you are looking for.</Typography>
         </div>
-        <Button href='/' component={Link} variant='contained'>
+        <Button href='/home' component={Link} variant='contained'>
           Back To Home
         </Button>
         <img


### PR DESCRIPTION
## Summary
- redirect users to `/home` after login and keep auth token in a cookie
- replace dashboard links with home across navigation menus and logo links
- update 404 page to link back to home

## Testing
- `npm run lint` *(fails: import ordering, padding-line-between-statements, etc.)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a56d1f0d2c83268a2ad7a49f1ebeeb